### PR TITLE
Declare protected $_xml class prop on XmlBuilder.php

### DIFF
--- a/src/Errbit/Utils/XmlBuilder.php
+++ b/src/Errbit/Utils/XmlBuilder.php
@@ -31,6 +31,8 @@ namespace Errbit\Utils;
  */
 class XmlBuilder
 {
+    protected ?\SimpleXMLElement $_xml;
+    
     /**
      * Instantiate a new XmlBuilder.
      *


### PR DESCRIPTION
For php 8.2 compatibility (deprecated dynamic property creation)